### PR TITLE
Add feature to clone non-personal (public) repos.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,8 @@ use std::process::{Command, Stdio};
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Name of the repo your need
-    repo: String,
-
-    /// Name of the host
-    host: Option<String>,
+    /// Address of the repo in the format uname/reponame
+    repo_address: String,
 
     /// Specify tag or branch
     checkout: Option<String>,
@@ -25,25 +22,22 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    // HashMap to store the entered args
-    let mut info_map: HashMap<&String, Vec<Option<String>>> = HashMap::new();
-    let mut info_vec: Vec<Option<String>> = Vec::new();
+    // Split the repo_address into uname and reponame
+    let parts: Vec<&str> = args.repo_address.split('/').collect();
+    if parts.len() != 2 {
+        eprintln!("Invalid repo address. Use the format uname/reponame");
+        std::process::exit(1);
+    }
 
-    // Update the info vector with author, host and checkout info
-    info_vec.push(args.host);
-    info_vec.push(args.checkout);
-
-    // Insert repo name as key with info vector as value
-    info_map.insert(&args.repo, info_vec);
+    let uname = parts[0];
+    let reponame = parts[1];
 
     // Git uname fetch
     let mut git_uname = Command::new("git");
 
     git_uname.arg("config").arg("--global").arg("user.name");
 
-    let git_uname = git_uname.stdout(Stdio::piped())
-        .output()
-        .unwrap();
+    let git_uname = git_uname.stdout(Stdio::piped()).output().unwrap();
 
     let mut stdout = String::from_utf8(git_uname.stdout).unwrap();
 
@@ -51,12 +45,18 @@ fn main() {
 
     // Git pull your repo
     let git_ssh_com: String = "git@github.com:".to_string();
-    let repo: String = args.repo.to_string();
 
-    let final_com = format!("{}{}/{}.git", git_ssh_com, stdout, repo);
+    let final_com = format!("{}{}/{}.git", git_ssh_com, stdout, reponame);
 
-    let mut gegit_com = Command::new("git");
+    let mut git_clone_com = Command::new("git");
 
-    gegit_com.arg("clone").arg(final_com);
-    gegit_com.output().unwrap();
+    git_clone_com.arg("clone").arg(final_com);
+    
+    if let Some(checkout) = args.checkout {
+        git_clone_com.arg("--branch").arg(checkout);
+    }
+
+    git_clone_com.arg(format!("--single-branch"));
+
+    git_clone_com.output().unwrap();
 }


### PR DESCRIPTION
This modification allows users to input the repo address in the format "uname/reponame." Additionally, it checks if the input is in the correct format and exits with an error message if not. The --branch and --single-branch options are added to the git clone command to support checking out specific branches if specified in the command line arguments.